### PR TITLE
removed annotation reference from comment

### DIFF
--- a/doc/cookbook/exclusion_strategies.rst
+++ b/doc/cookbook/exclusion_strategies.rst
@@ -24,7 +24,7 @@ then it is easier to change the exclusion policy, and only mark these few proper
 
     /**
      * The following annotations tells the serializer to skip all properties which
-     * have not marked with @Expose.
+     * have not marked with Expose.
      *
      * @ExclusionPolicy("all")
      */


### PR DESCRIPTION
If you use @Expose in a comment to explain annotation it will still be read as annotation and in this case it throws error that you can't use @Expose on class