### PR TITLE
#367 Exclude annotation not preventing attempt to find public methods…

### DIFF
--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -211,10 +211,10 @@ class AnnotationDriver implements DriverInterface
                     }
                 }
 
-                $propertyMetadata->setAccessor($accessType, $accessor[0], $accessor[1]);
 
                 if ((ExclusionPolicy::NONE === $exclusionPolicy && ! $isExclude)
                     || (ExclusionPolicy::ALL === $exclusionPolicy && $isExpose)) {
+                    $propertyMetadata->setAccessor($accessType, $accessor[0], $accessor[1]);
                     $classMetadata->addPropertyMetadata($propertyMetadata);
                 }
             }

--- a/tests/JMS/Serializer/Tests/Fixtures/GetSetObject.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/GetSetObject.php
@@ -19,6 +19,7 @@
 namespace JMS\Serializer\Tests\Fixtures;
 
 use JMS\Serializer\Annotation\AccessType;
+use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\ReadOnly;
 
@@ -35,6 +36,12 @@ class GetSetObject
      * @ReadOnly
      */
     private $readOnlyProperty = 42;
+
+    /**
+     * This property should be exlcluded
+     * @Exclude()
+     */
+    private $excludedProperty;
 
     public function getId()
     {


### PR DESCRIPTION
… when using AccessType

Attempt to find getters and setters only if property included to serialization