### PR TITLE
[doc] fix AccessorOrder documentation

### DIFF
--- a/doc/reference/annotations.rst
+++ b/doc/reference/annotations.rst
@@ -148,7 +148,7 @@ default the order is undefined, but you may change it to either "alphabetical", 
     }
 
     /**
-     * @AccessorOrder("custom", custom = {"name", "SomeMethod" ,"id"})
+     * @AccessorOrder("custom", custom = {"name", "someMethod" ,"id"})
      *
      * Resulting Property Order: name, mood, id
      */


### PR DESCRIPTION
Before, the documentation mentionned that in order to call the method in the AccessorOrder annotation, we should use only the method name stripped of its "get" prefix. But it forgot to mention that the stripped method should start with a lower case letter.
I fixed that minor typo.
